### PR TITLE
Define permissions using the correct format (`label` and `description`)

### DIFF
--- a/eventcheckin.php
+++ b/eventcheckin.php
@@ -49,8 +49,14 @@ function eventcheckin_civicrm_config(&$config)
  * Define custom (Drupal) permissions
  */
 function eventcheckin_civicrm_permission(&$permissions) {
-    $permissions['event checkin'] = E::ts('Check-In Event Participants');
-    $permissions['remote event checkin'] = E::ts('RemoteContacts: Check-In Event Participants');
+    $permissions['event checkin'] = [
+        'label' => E::ts('Check-In Event Participants'),
+        'description' => E::ts('Allows checking-in event participants.'),
+    ];
+    $permissions['remote event checkin'] = [
+        'label' => E::ts('RemoteContacts: Check-In Event Participants'),
+        'description' => E::ts('Allows checking-in event participants vie the CiviRemote API.')
+    ];
 }
 
 /**


### PR DESCRIPTION
Fixes `User deprecated function: Permission 'remote event checkin' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions in CRM_Core_Error::deprecatedWarning() (line 1129 of /path/to/civicrm/civicrm-core/CRM/Core/Error.php)`